### PR TITLE
Defect: if template strings are actually specified as the documentation ...

### DIFF
--- a/tasks/hg_release.js
+++ b/tasks/hg_release.js
@@ -13,7 +13,8 @@ module.exports = function(grunt) {
 		type = type || 'patch';
 	
 		var done = this.async(),
-			options = this.options({
+			that = this,
+			options = rawOptions({
 				commit: 'release-<%= version %>',
 				tag: 'release-<%= version %>'
 			});
@@ -48,6 +49,25 @@ module.exports = function(grunt) {
 			return grunt.template.process(template, {data: {version: version}});
 		}
 	
+		function aliasFunction(object, functionToAlias, newFunction, callback){
+			var originalFunction = object[functionToAlias];
+			var newFunction = object[newFunction];
+
+			object[functionToAlias] = newFunction;
+			callback(object);
+			object[functionToAlias] = originalFunction;
+		}
+
+		// override grunt.config.get() to be grunt.config.getRaw() and then call
+		// this.options() so that the template strings are not processed.
+		function rawOptions() {
+			var options;
+			var optionsArguments = arguments;
+			aliasFunction(grunt.config, 'get', 'getRaw', function(){
+				options = that.options.apply(that, optionsArguments);
+			});
+			return options;
+		};
 	});
 	
 };


### PR DESCRIPTION
...suggests, they will be interpolated/processed immediately when this.options() is called, which is before 'version' is defined.

Fix: use grunt.config.getRaw instead of grunt.config.get while calling this.options.
