### PR TITLE
Fix error: ok is not defined

### DIFF
--- a/tasks/hg_release.js
+++ b/tasks/hg_release.js
@@ -40,7 +40,7 @@ module.exports = function(grunt) {
 			var tag = getMessage(options.tag, version);
 			grunt.util.spawn({ cmd: "hg", args: [ "tag", tag ] }, function(err, result){
 				if (err) grunt.fail.fatal(err);
-				grunt.log,ok('Bumped to version: ' + version);
+				grunt.log.ok('Bumped to version: ' + version);
 				done();
 			});
 		}


### PR DESCRIPTION
Running "hg_release:minor" (hg_release) task
Fatal error: ok is not defined
